### PR TITLE
Move .dll from lib to bin

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 target_platform:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -5,7 +5,7 @@ arm_variant_type:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
 target_platform:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos7
 channel_sources:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
 target_platform:

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,7 +1,8 @@
 if not exist %PREFIX% mkdir %PREFIX%
 mkdir %PREFIX%/cuda-cupti
 
-move lib\* %LIBRARY_LIB%
+move lib\*.lib %LIBRARY_LIB%
+move lib\*.dll %LIBRARY_BIN%
 move include\* %LIBRARY_INC%
 move doc %PREFIX%
 move samples %PREFIX%

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ source:
   sha256: b65a34a3715e3ef2b835bdd36c43b21c20800325be1eda1e84ad4d80ee837c92  # [win]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [osx]
 
 test:
@@ -34,14 +34,21 @@ test:
     - test -L $PREFIX/lib/libcupti.so.{{ lib_version }}                                      # [linux]
     - test -L $PREFIX/targets/{{ target_name }}/lib/libcupti.so.{{ version.split(".")[0] }}  # [linux]
     - test -f $PREFIX/targets/{{ target_name }}/lib/libcupti.so.{{ lib_version }}            # [linux]
-    - if not exist %LIBRARY_LIB%\cupti64_{{ lib_version }}.dll exit 1              # [win]
+    - if not exist %LIBRARY_BIN%\checkpoint.dll exit 1                 # [win]
+    - if not exist %LIBRARY_BIN%\cupti64_{{ lib_version }}.dll exit 1  # [win]
+    - if not exist %LIBRARY_BIN%\nvperf_host.dll exit 1                # [win]
+    - if not exist %LIBRARY_BIN%\nvperf_target.dll exit 1              # [win]
+    - if not exist %LIBRARY_BIN%\pcsamplingutil.dll exit 1             # [win]
 
 outputs:
   - name: cuda-cupti
     files:
       - lib/libcupti*.so.*                    # [linux]
       - targets/{{ target_name }}/lib/*.so.*  # [linux]
-      - Library\lib\*.dll                     # [win]
+      - Library\bin\checkpoint.dll            # [win]
+      - Library\bin\cupti*.dll                # [win]
+      - Library\bin\nvperf*.dll               # [win]
+      - Library\bin\pcsamplingutil.dll        # [win]
     requirements:
       build:
         - {{ compiler("c") }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
The cupti build places both `.dll` and `.lib` in `lib` directory. Need to move `.dll` to `bin` so they can be detected when building downstream recipes.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
