### PR TITLE
Pin on full version on Windows [13.2]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About cuda-cupti-feedstock
 ==========================
 
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/cuda-cupti-feedstock/blob/main/LICENSE.txt)
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/agent-a0729e8032b2e8798-feedstock/blob/main/LICENSE.txt)
 
 Home: https://developer.nvidia.com/cuda-toolkit
 
@@ -21,8 +21,8 @@ Current build status
 <table><tr>
     <td>GitHub Actions</td>
     <td>
-      <a href="https://github.com/conda-forge/cuda-cupti-feedstock/actions/workflows/conda-build.yml">
-        <img src="https://github.com/conda-forge/cuda-cupti-feedstock/actions/workflows/conda-build.yml/badge.svg?event=push&branch=main">
+      <a href="https://github.com/conda-forge/agent-a0729e8032b2e8798-feedstock/actions/workflows/conda-build.yml">
+        <img src="https://github.com/conda-forge/agent-a0729e8032b2e8798-feedstock/actions/workflows/conda-build.yml/badge.svg?event=push&branch=main">
       </a>
     </td>
   </tr>
@@ -32,8 +32,8 @@ Current build status
     <td>
       <details>
         <summary>
-          <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19218&branchName=main">
-            <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cuda-cupti-feedstock?branchName=main">
+          <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=None&branchName=main">
+            <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/agent-a0729e8032b2e8798-feedstock?branchName=main">
           </a>
         </summary>
         <table>
@@ -41,8 +41,8 @@ Current build status
           <tbody><tr>
               <td>win_64</td>
               <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19218&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cuda-cupti-feedstock?branchName=main&jobName=win&configuration=win%20win_64_" alt="variant">
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=None&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/agent-a0729e8032b2e8798-feedstock?branchName=main&jobName=win&configuration=win%20win_64_" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -84,7 +84,8 @@ outputs:
   - name: cuda-cupti-dev
     build:
       run_exports:
-        - {{ pin_subpackage("cuda-cupti", max_pin="x") }}
+        - {{ pin_subpackage("cuda-cupti", max_pin="x") }}      # [linux]
+        - {{ pin_subpackage("cuda-cupti", max_pin="x.x.x") }}  # [win]
     files:
       - lib/checkpoint.so                         # [linux]
       - lib/libcupti.so                           # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
   sha256: 8b91f32f346a9e3d15d8d8fcba3c8fbf5e87c1aec448f0477e88ac36ef0a46b2  # [win]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [osx or ppc64le]
 
 requirements:


### PR DESCRIPTION
Checklist
* [x] Used a personal fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] Re-rendered with the latest `conda-smithy`
* [ ] Ensured the license file is being packaged.

Backport of #40 to the 13.2 branch.

Fixes the `run_exports` pin for `cuda-cupti-dev` on Windows to use full version pinning (`x.x.x`) instead of major-only (`x`).

Closes #39